### PR TITLE
Fix permissions issue

### DIFF
--- a/espeon/command/install_dependencies.lua
+++ b/espeon/command/install_dependencies.lua
@@ -11,7 +11,7 @@ return {
       exec({
         'sudo apt-get install screen',
         'sudo apt-get install python-pip',
-        'sudo pip install esptool --upgrade',
+        'sudo -H pip install esptool --upgrade',
         'which npm > /dev/null || sudo apt install nodejs',
         'npm install -g nodemcu-tool || sudo npm install -g nodemcu-tool'
       })


### PR DESCRIPTION
Not sure if this is correct, or whether it needs to be applied for the mac, but I got the following error on two computers running Ubuntu without it:
```
espeon install_dependencies
[sudo] password for robert: 
/home/robert/.lenv/lua/5.1.5/bin/lua: .../.lenv/lua/5.1.5/share/lua/5.1/espeon/util/shell.lua:16: The directory '/home/robert/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
The directory '/home/robert/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.

stack traceback:
        [C]: in function 'error'
        .../.lenv/lua/5.1.5/share/lua/5.1/espeon/util/shell.lua:16: in function 'shell'
        ...t/.lenv/lua/5.1.5/share/lua/5.1/espeon/util/exec.lua:9: in function 'exec'
        ...hare/lua/5.1/espeon/command/install_dependencies.lua:11: in function 'execute'
        ...bert/.lenv/lua/5.1.5/share/lua/5.1/espeon/espeon.lua:17: in function <...bert/.lenv/lua/5.1.5/share/lua/5.1/espeon/espeon.lua:1>
        ....1.5/lib/luarocks/rocks-5.1/espeon/1.10-0/bin/espeon:3: in main chunk
        [C]: ?
```