### PR TITLE
Run without prompting user

### DIFF
--- a/espeon/command/format.lua
+++ b/espeon/command/format.lua
@@ -9,7 +9,7 @@ return {
 
     print('Formatting filesystem...')
     exec('nodemcu-tool --port ' .. serial_port .. ' reset && sleep 1.5')
-    exec('nodemcu-tool --port ' .. serial_port .. ' mkfs')
+    exec('nodemcu-tool --port ' .. serial_port .. ' mkfs --noninteractive')
     print()
   end
 }


### PR DESCRIPTION
With the latest changes, `nodemcu-tool` prompts the user to type "yes", but you can't see it because we hide the output. This fixes that.